### PR TITLE
Feature/ac 27978

### DIFF
--- a/0.1.0
+++ b/0.1.0
@@ -48,22 +48,16 @@
                },
                "subTaskList":[
                   {
-                     "description":"Profile Modifications",
+                     "description":"Allow users to update records with inactive users as owners",
                      "taskList":[
                         {
                            "jiraTicket":"AC-720b",
                            "actionType":"ProfilePermission",
                            "actionTypeName":"AC Basic User",
-                           "subTaskList":[
-                              {
-                                 "jiraTicket":"ac-720b",
-                                 "description":"Allow users to update records with inactive users as owners",
-                                 "optionsMap":{
-                                    "UpdateWithInactiveOwner":true,
-                                    "CreateAuditFields":true
-                                 }
-                              }
-                           ]
+                           "optionsMap":{
+                              "UpdateWithInactiveOwner":true,
+                              "CreateAuditFields":true
+                           }
                         }
                      ]
                   }

--- a/0.1.0
+++ b/0.1.0
@@ -37,7 +37,7 @@
          "instructionTypeName":"DeclarativeMetadata",
          "taskList":[
             {
-               "jiraTicket":"AC-720",
+               "jiraTicket":"AC-720a",
                "actionType":"DeclarativeMetadata",
                "actionTypeName":"DeclarativeMetadata",
                "optionsMap":{
@@ -46,6 +46,26 @@
                   "filePath":"settings/Security.settings",
                   "coupledFields":"<enableAuditFieldsInactiveOwner>false</enableAuditFieldsInactiveOwner>,<enableAuditFieldsInactiveOwner>true</enableAuditFieldsInactiveOwner>"
                }
+            }
+         ]
+      },
+      {
+         "description": "Profile Modifications",
+         "taskList":[
+            {
+               "jiraTicket":"AC-720b",
+               "actionType":"ProfilePermission",
+               "actionTypeName":"AC Basic User",
+               "subTaskList":[
+                  {
+                     "jiraTicket":"ac-720",
+                     "description":"Allow users to update records with inactive users as owners",
+                     "optionsMap":{
+                        "UpdateWithInactiveOwner":true,
+                        "CreateAuditFields":true
+                     }
+                  }
+               ]
             }
          ]
       }

--- a/0.1.0
+++ b/0.1.0
@@ -58,7 +58,7 @@
                "actionTypeName":"AC Basic User",
                "subTaskList":[
                   {
-                     "jiraTicket":"ac-720",
+                     "jiraTicket":"ac-720b",
                      "description":"Allow users to update records with inactive users as owners",
                      "optionsMap":{
                         "UpdateWithInactiveOwner":true,

--- a/0.1.0
+++ b/0.1.0
@@ -50,17 +50,13 @@
                   {
                      "instructionTypeName":"ProfilePermission",
                      "description":"Allow users to update records with inactive users as owners",
-                     "taskList":[
-                        {
-                           "jiraTicket":"AC-720b",
-                           "actionType":"ProfilePermission",
-                           "actionTypeName":"AC Basic User",
-                           "optionsMap":{
-                              "UpdateWithInactiveOwner":true,
-                              "CreateAuditFields":true
-                           }
-                        }
-                     ]
+                     "jiraTicket":"AC-720b",
+                     "actionType":"ProfilePermission",
+                     "actionTypeName":"AC Basic User",
+                     "optionsMap":{
+                        "UpdateWithInactiveOwner":true,
+                        "CreateAuditFields":true
+                     }
                   }
                ]
             }

--- a/0.1.0
+++ b/0.1.0
@@ -45,25 +45,27 @@
                   "packageMember":"Settings",
                   "filePath":"settings/Security.settings",
                   "coupledFields":"<enableAuditFieldsInactiveOwner>false</enableAuditFieldsInactiveOwner>,<enableAuditFieldsInactiveOwner>true</enableAuditFieldsInactiveOwner>"
-               }
-            }
-         ]
-      },
-      {
-         "description": "Profile Modifications",
-         "taskList":[
-            {
-               "jiraTicket":"AC-720b",
-               "actionType":"ProfilePermission",
-               "actionTypeName":"AC Basic User",
+               },
                "subTaskList":[
                   {
-                     "jiraTicket":"ac-720b",
-                     "description":"Allow users to update records with inactive users as owners",
-                     "optionsMap":{
-                        "UpdateWithInactiveOwner":true,
-                        "CreateAuditFields":true
-                     }
+                     "description":"Profile Modifications",
+                     "taskList":[
+                        {
+                           "jiraTicket":"AC-720b",
+                           "actionType":"ProfilePermission",
+                           "actionTypeName":"AC Basic User",
+                           "subTaskList":[
+                              {
+                                 "jiraTicket":"ac-720b",
+                                 "description":"Allow users to update records with inactive users as owners",
+                                 "optionsMap":{
+                                    "UpdateWithInactiveOwner":true,
+                                    "CreateAuditFields":true
+                                 }
+                              }
+                           ]
+                        }
+                     ]
                   }
                ]
             }

--- a/0.1.0
+++ b/0.1.0
@@ -48,6 +48,7 @@
                },
                "subTaskList":[
                   {
+                     "instructionTypeName":"ProfilePermission",
                      "description":"Allow users to update records with inactive users as owners",
                      "taskList":[
                         {


### PR DESCRIPTION
The ‘Enable "Set Audit Fields upon Record Creation" and "Update Records with Inactive Owners" User Permissions’ settings have been activated and can be found in setup -> User Interface. Also this activates the permission Update Records with Inactive Owners for AC basic user.