### PR TITLE
Change case on Status api name

### DIFF
--- a/1.3.1
+++ b/1.3.1
@@ -6,7 +6,7 @@
             {
                "jiraTicket":"AC-40855",
                "actionType":"PicklistValueCustom",
-               "actionTypeName":"command__status__c",
+               "actionTypeName":"command__Status__c",
                "optionsMap":{
                   "sortList":true,
                   "picklistValues":"Completed,Pending,Failed"


### PR DESCRIPTION
Casing didn't match in the instructions compared to the field api name so we had an error because the system thought we were trying to change the API name and it didn't like that _at all_

I did run this instruction against howard bailey UAT to verify this was the issue.