### PR TITLE
feature/ac-44251 | Add the related list to the Household layout | AC Package 1.5

### DIFF
--- a/1.5.0
+++ b/1.5.0
@@ -112,6 +112,20 @@
                }
             }
          ]
+      },
+      {
+         "sObjectName": "Account",
+         "instructionTypeName": "command__AC Account (Household) Layout",
+         "description": "Add HouseHold Related list on the household layout",
+         "taskList": [
+            {
+               "jiraTicket": "ac-44251a",
+               "description": "Add related list to enable the Household opportunities on the lighting page",
+               "actionType": "RelatedList",
+               "actionTypeName": "Opportunity.FinServ__Household__c",
+               "optionsMap": {}
+            }
+         ]
       }
    ]
 }


### PR DESCRIPTION
This instruction is for adding the related list to the household layout to make the 'Household Opportunities' visible on the new Household Lighting page .

Depends on Pull requests  Ac-44251 [Sf-ac #223](https://github.com/advisors-excel-llc/sf-ac/pull/223)
 And AC-3971 [Sf-ac #213](https://github.com/advisors-excel-llc/sf-ac/pull/213)