### PR TITLE
feature/removeInstruction | Remove Instruction from 1.5.0 | AC package 1.5

### DIFF
--- a/1.5.0
+++ b/1.5.0
@@ -400,25 +400,6 @@
                  }
              }
          ]
-      },
-      {
-         "sObjectName": "Global",
-         "instructionTypeName": "command__Global Layout",
-         "description": "Remove Platform actions from Global Layout",
-         "taskList": [
-            {
-               "jiraTicket": "ac-46595",
-               "description": "Remove standard New note from Global layout Mobile and Lightning Actions section",
-               "actionType": "PlatformAction",
-               "actionTypeName": "nothing",
-               "optionsMap": {
-                  "platformActionType": "QuickAction",
-                  "platformActionName": "FeedItem.ContentNote",
-                  "platformActionListContext": "Global",
-                  "operation": "remove"
-               }
-            }
-         ]
       }
    ]
 }


### PR DESCRIPTION
Remove the global action instruction from 1.5.0 
And added in path  https://github.com/advisors-excel-llc/ac-metadata-instructions/pull/91