### PR TITLE
Adding version to patch files

### DIFF
--- a/1.5.1
+++ b/1.5.1
@@ -1,4 +1,5 @@
 {
+    "version": "patch 1.5.1",
     "instructionList": [
         {
             "sObjectName": "Activity",

--- a/1.5.2
+++ b/1.5.2
@@ -1,4 +1,5 @@
 {
+    "version": "patch 1.5.2",
     "instructionList": [
         {
             "sObjectName": "Global",


### PR DESCRIPTION
Added version to patch files to prevent the metadata version records from setting a record id to the record name. 