### PR TITLE
defect/ac-51313 | Remove standard New Note Button from layouts

### DIFF
--- a/1.5.2
+++ b/1.5.2
@@ -1,0 +1,346 @@
+{
+    "instructionList": [
+        {
+            "sObjectName": "Global",
+            "instructionTypeName": "command__Global Layout",
+            "description": "Remove Platform actions from Global Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595a",
+                    "description": "Remove standard New note from Global layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Global",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Account",
+            "instructionTypeName": "command__AC Account (Household) Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595b",
+                    "description": "Remove standard New note from layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Account",
+            "instructionTypeName": "command__Account Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595c",
+                    "description": "Remove standard New note from layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Campaign",
+            "instructionTypeName": "command__AC Campaign Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595d",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Campaign",
+            "instructionTypeName": "command__Campaign Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595e",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "FinServ__FinancialAccount__c",
+            "instructionTypeName": "command__Financial Account (Annuity) Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595f",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "FinServ__FinancialAccount__c",
+            "instructionTypeName": "command__Financial Account(AUM) Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595g",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "FinServ__FinancialAccount__c",
+            "instructionTypeName": "command__Financial Account(Life) Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595h",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "FinServ__FinancialAccount__c",
+            "instructionTypeName": "command__Financial Account (REIT/Mutual Fund/Other) Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595i",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Lead",
+            "instructionTypeName": "command__AC Lead Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595j",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Lead",
+            "instructionTypeName": "FinServ__Lead (General) Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595k",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Opportunity",
+            "instructionTypeName": "command__AC Opportunity Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595l",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Opportunity",
+            "instructionTypeName": "FinServ__Opportunity (General) Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595m",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Opportunity",
+            "instructionTypeName": "command__Opportunity Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595n",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "PersonAccount",
+            "instructionTypeName": "command__Client",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595p",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "PersonAccount",
+            "instructionTypeName": "command__Person Account Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595q",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Task",
+            "instructionTypeName": "command__AC Task Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595r",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "Event",
+            "instructionTypeName": "command__Event Layout",
+            "description": "Remove Platform actions from Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595s",
+                    "description": "Remove standard New note from  layout Mobile and Lightning Actions section",
+                    "actionType": "PlatformAction",
+                    "actionTypeName": "nothing",
+                    "optionsMap": {
+                        "platformActionType": "QuickAction",
+                        "platformActionName": "FeedItem.ContentNote",
+                        "platformActionListContext": "Record",
+                        "operation": "remove"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This was mistakenly in the patch branch so moving it over to develop