### PR TITLE
defect/ac-52811 | Remove old 'new note' quick action from layouts

### DIFF
--- a/1.5.2
+++ b/1.5.2
@@ -16,6 +16,14 @@
                         "platformActionListContext": "Global",
                         "operation": "remove"
                     }
+                },
+                {
+                    "jiraTicket": "ac-46595x",
+                    "actionType": "QuickAction",
+                    "actionTypeName": "FeedItem.ContentNote",
+                    "optionsMap": {
+                        "operation": "remove"
+                    }
                 }
             ]
         },

--- a/1.5.2
+++ b/1.5.2
@@ -341,6 +341,66 @@
                     }
                 }
             ]
+        },
+        {
+            "sObjectName": "FinServ__FinancialAccount__c",
+            "instructionTypeName": "command__Financial Account (Annuity) Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595t",
+                    "description": "Remove standard New note from quick actions",
+                    "actionType": "QuickAction",
+                    "actionTypeName": "FeedItem.ContentNote",
+                    "optionsMap": {
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "FinServ__FinancialAccount__c",
+            "instructionTypeName": "command__Financial Account(AUM) Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595u",
+                    "description": "Remove standard New note from quick actions",
+                    "actionType": "QuickAction",
+                    "actionTypeName": "FeedItem.ContentNote",
+                    "optionsMap": {
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "FinServ__FinancialAccount__c",
+            "instructionTypeName": "command__Financial Account(Life) Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595v",
+                    "description": "Remove standard New note from quick actions",
+                    "actionType": "QuickAction",
+                    "actionTypeName": "FeedItem.ContentNote",
+                    "optionsMap": {
+                        "operation": "remove"
+                    }
+                }
+            ]
+        },
+        {
+            "sObjectName": "FinServ__FinancialAccount__c",
+            "instructionTypeName": "command__Financial Account (REIT/Mutual Fund/Other) Layout",
+            "taskList": [
+                {
+                    "jiraTicket": "ac-46595w",
+                    "description": "Remove standard New note from quick actions",
+                    "actionType": "QuickAction",
+                    "actionTypeName": "FeedItem.ContentNote",
+                    "optionsMap": {
+                        "operation": "remove"
+                    }
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Includes instructions to remove the standard 'new note' button on layouts and the global layout.