### PR TITLE
defect?ac-63969 | Person Account Record Type Label Not Updated to 'Client'

### DIFF
--- a/1.9.0
+++ b/1.9.0
@@ -771,6 +771,19 @@
           }
         }
       ]
+    },
+    {
+      "sObjectName":"PersonAccount",
+      "instructionTypeName":"UpdateRecordTypeLabel",
+      "description":"Update Record Type Label of Person Account to Client",
+      "taskList":[
+        {
+          "jiraTicket":"ac-63969",
+          "actionType":"UpdateRecordTypeLabel",
+          "actionTypeName":"PersonAccount",
+          "actionTypeLabel":"Client"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
to test in scratch org change actionTypeName to command__PersonAccount since namepace is used in scratch org, but its not in the regular orgs for the record type